### PR TITLE
added lockdown example via Callback

### DIFF
--- a/script/ode_lockdown/ode_lockdown.jl
+++ b/script/ode_lockdown/ode_lockdown.jl
@@ -1,0 +1,41 @@
+
+using DifferentialEquations
+using Plots
+
+function sir_ode!(du,u,p,t)
+    (S,I,R) = u
+    (β,c,γ) = p
+    N = S+I+R
+    @inbounds begin
+        du[1] = -β*c*I/N*S
+        du[2] = β*c*I/N*S - γ*I
+        du[3] = γ*I
+    end
+    nothing
+end
+δt = 0.1
+tmax = 80.0
+tspan = (0.0,tmax)
+t = 0.0:δt:tmax;
+
+u0 = [990.0,10.0,0.0]; # S,I.R
+
+p = [0.05,10.0,0.25]; # β,c,γ
+
+lockdown_times = [10.0, 20.0]
+condition(u,t,integrator) = t ∈ lockdown_times  
+function affect!(integrator) 
+    if integrator.t < lockdown_times[2] 
+        integrator.p[1] = 0.01
+    else
+        integrator.p[1] = 0.05
+    end
+end
+cb = PresetTimeCallback(lockdown_times, affect!)
+
+prob_ode = ODEProblem(sir_ode!,u0,tspan,p)
+
+sol_ode = solve(prob_ode, callback = cb);
+
+plot(sol_ode, label = ["S" "I" "R"], title = "Lockdown in a SIR model")
+vline!(lockdown_times, c = :red, w = 2, label = "")

--- a/tutorials/ode_lockdown/ode_lockdown.jmd
+++ b/tutorials/ode_lockdown/ode_lockdown.jmd
@@ -1,0 +1,103 @@
+# Ordinary differential equation model with time varying beta (lookdown)
+Florian Oswald (@floswald), 2021-01-20
+
+## Introduction
+
+This is the classical ODE version of the SIR model with a temporary lockdown policy in place.
+
+- Deterministic
+- Continuous in time
+- Continuous in state
+
+## Libraries
+
+```julia
+using DifferentialEquations
+using Plots
+```
+
+## Transitions
+
+The following function provides the derivatives of the model, which it changes in-place. State variables and parameters are unpacked from `u` and `p`; this incurs a slight performance hit, but makes the equations much easier to read.
+
+```julia
+function sir_ode!(du,u,p,t)
+    (S,I,R) = u
+    (β,c,γ) = p
+    N = S+I+R
+    @inbounds begin
+        du[1] = -β*c*I/N*S
+        du[2] = β*c*I/N*S - γ*I
+        du[3] = γ*I
+    end
+    nothing
+end;
+```
+
+## Time domain
+
+We set the timespan for simulations, `tspan`, initial conditions, `u0`, and parameter values, `p` (which are unpacked above as `[β,γ]`).
+
+```julia
+δt = 0.1
+tmax = 80.0
+tspan = (0.0,tmax)
+t = 0.0:δt:tmax;
+```
+
+## Initial conditions
+
+```julia
+u0 = [990.0,10.0,0.0]; # S,I.R
+```
+
+## Parameter values
+
+```julia
+p = [0.05,10.0,0.25]; # β,c,γ
+```
+
+## Programming a Lockdown
+
+Suppose we impose a lockdown which will reduce the transmission rate $\beta$ to a lower value. For example's sake
+suppose we reduce $\beta$ to 0.01 starting in period 10 and up until period 20. 
+
+```julia
+lockdown_times = [10.0, 20.0]
+condition(u,t,integrator) = t ∈ lockdown_times  
+function affect!(integrator) 
+    if integrator.t < lockdown_times[2] 
+        integrator.p[1] = 0.01
+    else
+        integrator.p[1] = 0.05
+    end
+end
+cb = PresetTimeCallback(lockdown_times, affect!)
+```
+
+## Running the model
+
+```julia
+prob_ode = ODEProblem(sir_ode!,u0,tspan,p)
+```
+
+Call the solver with the specified callback function.
+
+```julia
+sol_ode = solve(prob_ode, callback = cb);
+```
+## Post-processing
+
+Let's use the `plot` recipe from the `DifferentialEquations` package:
+
+```julia
+plot(sol_ode, label = ["S" "I" "R"], title = "Lockdown in a SIR model")
+vline!(lockdown_times, c = :red, w = 2, label = "")
+df_ode[!,:t] = t;
+```
+
+
+```{julia; echo=false; skip="notebook"}
+include(joinpath(@__DIR__,"tutorials","appendix.jl"))
+appendix()
+```


### PR DESCRIPTION
simple lockdown example in the ODE example. i wasn't able to get the Weave thing to work:

```
(sir-julia) pkg> instantiate
   Updating registry at `~/.julia/registries/General`
   Updating git-repo `https://github.com/JuliaRegistries/General.git`
ERROR: expected package `Gillespie [523d8e89]` to be registered

(sir-julia) pkg> rm Gillespie
Updating `~/git/sir-julia/Project.toml`
  [523d8e89] - Gillespie
No Changes to `~/git/sir-julia/Manifest.toml`

(sir-julia) pkg> instantiate
ERROR: `DrWatson` is a direct dependency, but does not appear in the manifest. If you intend `DrWatson` to be a direct dependency, run `Pkg.resolve()` to populate the manifest. Otherwise, remove `DrWatson` with `Pkg.rm("DrWatson")`. Finally, run `Pkg.instantiate()` again.
```

## output

lockdown from period 10 to 20.

<img width="715" alt="Screenshot 2021-01-20 at 22 10 30" src="https://user-images.githubusercontent.com/1021558/105236233-4fe5fc00-5b6c-11eb-962c-b2690d13dbd5.png">
